### PR TITLE
Updating lockfile to handle ruby v3

### DIFF
--- a/.bundle/config
+++ b/.bundle/config
@@ -1,2 +1,0 @@
----
-BUNDLE_PATH: "vendor/bundle"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -3,29 +3,29 @@ GEM
   specs:
     ast (2.4.2)
     coderay (1.1.3)
-    diff-lcs (1.4.4)
+    diff-lcs (1.5.0)
     method_source (1.0.0)
-    parallel (1.20.1)
-    parser (3.0.0.0)
+    parallel (1.22.1)
+    parser (3.2.1.1)
       ast (~> 2.4.1)
     powerpack (0.1.3)
-    pry (0.14.0)
+    pry (0.14.2)
       coderay (~> 1.1)
       method_source (~> 1.0)
-    rainbow (3.0.0)
-    rspec (3.10.0)
-      rspec-core (~> 3.10.0)
-      rspec-expectations (~> 3.10.0)
-      rspec-mocks (~> 3.10.0)
-    rspec-core (3.10.1)
-      rspec-support (~> 3.10.0)
-    rspec-expectations (3.10.1)
+    rainbow (3.1.1)
+    rspec (3.12.0)
+      rspec-core (~> 3.12.0)
+      rspec-expectations (~> 3.12.0)
+      rspec-mocks (~> 3.12.0)
+    rspec-core (3.12.1)
+      rspec-support (~> 3.12.0)
+    rspec-expectations (3.12.2)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-mocks (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-mocks (3.12.4)
       diff-lcs (>= 1.2.0, < 2.0)
-      rspec-support (~> 3.10.0)
-    rspec-support (3.10.2)
+      rspec-support (~> 3.12.0)
+    rspec-support (3.12.0)
     rubocop (0.56.0)
       parallel (~> 1.10)
       parser (>= 2.5)
@@ -33,11 +33,11 @@ GEM
       rainbow (>= 2.2.2, < 4.0)
       ruby-progressbar (~> 1.7)
       unicode-display_width (~> 1.0, >= 1.0.1)
-    ruby-progressbar (1.11.0)
-    unicode-display_width (1.7.0)
+    ruby-progressbar (1.13.0)
+    unicode-display_width (1.8.0)
 
 PLATFORMS
-  ruby
+  x86_64-darwin-22
 
 DEPENDENCIES
   pry
@@ -45,4 +45,4 @@ DEPENDENCIES
   rubocop (= 0.56.0)
 
 BUNDLED WITH
-   1.17.2
+   2.4.6

--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ I want to know my drop off point
 ## Instructions to clone to your computer
 
 1. Clone the repo, instructions can be found [here](https://docs.github.com/en/github/creating-cloning-and-archiving-repositories/cloning-a-repository)
-2. You will need to install the dependencies (known as Ruby gems), to do this use the command `bundle install --path vendor/bundle`
+2. You will need to install the dependencies (known as Ruby gems), to do this use the command `bundle install`
 3. To run the rspec tests run the command `bundle exec rspec` from your terminal
 4. There will be a few tests that are failing - debug to fix them
 

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ I want to know my drop off point
 
 1. Go to https://repl.it/ and sign up if you don't have an account
 2. Select to create a new Replit and upload fromm github. Use the link https://github.com/Caitlin-cooling/uber-AIP note that this is cloning and can take a little while - watch the progress in your console tab
-3. The dependencies will be installed for you, just run `rspec` in your console to run the tests
+3. The dependencies will be installed for you, just run `bundle exec rspec` in your console to run the tests
 4. There will be a few tests that are failing - debug to fix them
 
 If you get all tests passing and have some time to spare, have a go at finishing the app using these user stories. You will want to write tests to ensure everything is working as expected.


### PR DESCRIPTION
Ruby V3 has been out for a while, is the only version available in repl.it, and will likely be the version used by the trainees since they will be installing ruby fresh (i.e. `brew install ruby`). 

The curry lock file forces the usage of v1 of bundler, and then fails to install the gems. 

This lock file was generated by removing the lock file and running `bundle install`. 
(We could also think about just not having the lock file) 
